### PR TITLE
Bugfix/filestream frame count

### DIFF
--- a/3es-core/3espacketstream.h
+++ b/3es-core/3espacketstream.h
@@ -167,7 +167,7 @@ namespace tes
     switch (pos)
     {
     case Begin:
-      if (offset <= _packet->payloadSize)
+      if (offset <= payloadSize())
       {
         _payloadPosition = uint16_t(offset);
         return true;
@@ -175,7 +175,7 @@ namespace tes
       break;
 
     case Current:
-      if (offset >= 0 && offset + _payloadPosition <= _packet->payloadSize ||
+      if (offset >= 0 && offset + _payloadPosition <= payloadSize() ||
         offset < 0 && _payloadPosition >= -offset)
       {
         _payloadPosition = uint16_t(_payloadPosition + offset);
@@ -184,7 +184,7 @@ namespace tes
       break;
 
     case End:
-      if (offset < _packet->payloadSize)
+      if (offset < payloadSize())
       {
         _payloadPosition = uint16_t(_packet->payloadSize - 1 - offset);
         return true;

--- a/3es-core/3esstreamutil.cpp
+++ b/3es-core/3esstreamutil.cpp
@@ -1,0 +1,228 @@
+//
+// author: Kazys Stepanas
+//
+#include "3esstreamutil.h"
+
+#include "3esmessages.h"
+#include "3espacketwriter.h"
+
+#include <iostream>
+#include <vector>
+
+namespace tes
+{
+  namespace streamutil
+  {
+    bool initialiseStream(std::ostream &stream, const ServerInfoMessage *serverInfo)
+    {
+      const uint16_t packetBufferSize = 256;
+      uint8_t packetBuffer[packetBufferSize];
+      PacketWriter packet(packetBuffer, packetBufferSize);
+
+      if (serverInfo)
+      {
+        packet.reset(MtServerInfo, 0);
+        if (!serverInfo->write(packet))
+        {
+          return false;
+        }
+
+        if (!packet.finalise())
+        {
+          return false;
+        }
+
+        stream.write(reinterpret_cast<const char *>(packet.data()), packet.packetSize());
+        if (!stream.good() || stream.fail())
+        {
+          return false;
+        }
+      }
+
+      // Write a frame count control message place holder.
+      packet.reset(MtControl, CIdFrameCount);
+      ControlMessage msg;
+      msg.controlFlags = 0;
+      msg.value32 = 0;
+      msg.value64 = 0;
+
+      if (!msg.write(packet))
+      {
+        return false;
+      }
+
+      if (!packet.finalise())
+      {
+        return false;
+      }
+
+      stream.write(reinterpret_cast<const char *>(packet.data()), packet.packetSize());
+      if (!stream.good() || stream.fail())
+      {
+        return false;
+      }
+
+      return true;
+    }
+
+
+    bool finaliseStream(std::iostream &stream, unsigned frameCount)
+    {
+      // Rewind the stream to the beginning and find the first RoutingID.ServerInfo message
+      // and RoutingID.Control message with a ControlMessageID.FrameCount ID. These should be
+      // the first and second messages in the stream.
+      // We'll limit searching to the first 5 messages.
+      std::streampos serverInfoMessageStart = -1;
+      std::streampos frameCountMessageStart = -1;
+      stream.flush();
+
+      // Record the initial stream position to restore later.
+      std::streampos restorePos = stream.tellp();
+
+      // Set the read position to search for the relevant messages.
+      stream.seekg(0);
+
+      std::streampos streamPos = 0;
+
+      std::vector<uint8_t> headerBuffer(1024);
+      auto markerValidation = PacketMarker;
+      const char *markerValidationBytes = (const char *)&markerValidation;
+      networkEndianSwap(markerValidation);
+      decltype(PacketMarker) marker = 0;
+      char *markerBytes = (char *)&marker;
+      bool markerValid = false;
+
+      int attemptsRemaining = 5;
+      int byteReadLimit = 0;
+
+      while ((frameCountMessageStart < 0 || serverInfoMessageStart < 0) && attemptsRemaining > 0 && stream.good())
+      {
+        --attemptsRemaining;
+        markerValid = false;
+
+        // Limit the number of bytes we try read in each attempt.
+        byteReadLimit = 1024;
+        while (byteReadLimit > 0)
+        {
+          --byteReadLimit;
+          // Record the potential marker start position.
+          streamPos = stream.tellg();
+          stream.read(markerBytes, 1);
+          if (markerBytes[0] == markerValidationBytes[0])
+          {
+            markerValid = true;
+            int i = 1;
+            for (i = 1; markerValid && stream.good() && i < int(sizeof(markerValidation)); ++i)
+            {
+              stream.read(markerBytes + i, 1);
+              markerValid = markerValid && markerBytes[i] == markerValidationBytes[i];
+            }
+
+            if (markerValid)
+            {
+              break;
+            }
+            else
+            {
+              // We've failed to fully validate the maker. However, we did read and validate
+              // one byte in the marker, then continued reading until the failure. It's possible
+              // that the last byte read, the failed byte, may be the start of the actual marker.
+              // We check this below, and if so, we rewind the stream one byte in order to
+              // start validation from there on the next iteration. We can ignore the byte if
+              // it is does not match the first validation byte. We are unlikely to ever make this
+              // match though.
+              --i;  // Go back to the last read byte.
+              if (markerBytes[i] == markerValidationBytes[0])
+              {
+                // Potentially the start of a new marker. Rewind the stream to attempt to validate it.
+                stream.seekg(-1, std::ios_base::cur);
+              }
+            }
+          }
+        }
+
+        if (markerValid && stream.good())
+        {
+          // Potential packet target. Return to the start of the marker.
+          stream.seekg(streamPos);
+
+          // Read the packet header.
+          stream.read((char *)headerBuffer.data(), sizeof(PacketHeader));
+          auto bytesRead = stream.tellg() - streamPos;
+          if (bytesRead == sizeof(PacketHeader))
+          {
+            // Resolve the packet size.
+            unsigned packetSize = PacketReader((PacketHeader *)headerBuffer.data()).packetSize();
+
+            // Read additional bytes.
+            if (packetSize > sizeof(PacketHeader))
+            {
+              const auto preReadPos = stream.tellg();
+              stream.read((char *)headerBuffer.data() + sizeof(PacketHeader), packetSize - sizeof(PacketHeader));
+              bytesRead = stream.tellg() - preReadPos;
+            }
+
+            // Convert into a PacketReader to support endian fixes.
+            const PacketReader currentPacket((const PacketHeader *)headerBuffer.data());
+
+            // Check packet/message type.
+            if (currentPacket.routingId() == MtServerInfo)
+            {
+              serverInfoMessageStart = streamPos;
+            }
+            else if (currentPacket.routingId() == MtControl && currentPacket.messageId() == CIdFrameCount)
+            {
+              // It's the frame count control message. Set the offset to the frame count member.
+              frameCountMessageStart = streamPos;
+            }
+            else
+            {
+              // At this point, we've failed to find the right kind of header. We could use the payload size to
+              // skip ahead in the stream which should align exactly to the next message.
+              // Not done for initial testing.
+            }
+          }
+        }
+      }
+
+      // if (serverInfoMessageStart >= 0)
+      // {
+      //   // Found the correct location. Seek the stream to here and write a new FrameCount control message.
+      //   stream.seekp(serverInfoMessageStart);
+      //   PacketWriter packet(headerBuffer.data(), uint16_t(headerBuffer.size()), MtServerInfo);
+
+      //   _serverInfo.write(packet);
+      //   packet.finalise();
+      //   stream.write((const char *)headerBuffer.data(), packet.packetSize());
+      //   stream.flush();
+      // }
+
+      if (frameCountMessageStart >= 0)
+      {
+        // Found the correct location. Seek the stream to here and write a new FrameCount control message.
+        stream.seekp(frameCountMessageStart);
+
+        PacketWriter packet(headerBuffer.data(), uint16_t(headerBuffer.size()), MtControl, CIdFrameCount);
+        ControlMessage frameCountMsg;
+
+        frameCountMsg.controlFlags = 0;
+        frameCountMsg.value32 = frameCount;
+        frameCountMsg.value64 = 0;
+
+        frameCountMsg.write(packet);
+        packet.finalise();
+        stream.write((const char *)headerBuffer.data(), packet.packetSize());
+        stream.flush();
+      }
+
+      if (restorePos > 0)
+      {
+        stream.seekp(restorePos);
+        stream.seekg(restorePos);
+        stream.flush();
+      }
+
+      return stream.good();
+    }
+  } // namespace streamutil
+} // namespace tes

--- a/3es-core/3esstreamutil.cpp
+++ b/3es-core/3esstreamutil.cpp
@@ -66,7 +66,7 @@ namespace tes
     }
 
 
-    bool finaliseStream(std::iostream &stream, unsigned frameCount)
+    bool finaliseStream(std::iostream &stream, unsigned frameCount, const ServerInfoMessage *serverInfo)
     {
       // Rewind the stream to the beginning and find the first RoutingID.ServerInfo message
       // and RoutingID.Control message with a ControlMessageID.FrameCount ID. These should be
@@ -185,17 +185,18 @@ namespace tes
         }
       }
 
-      // if (serverInfoMessageStart >= 0)
-      // {
-      //   // Found the correct location. Seek the stream to here and write a new FrameCount control message.
-      //   stream.seekp(serverInfoMessageStart);
-      //   PacketWriter packet(headerBuffer.data(), uint16_t(headerBuffer.size()), MtServerInfo);
+      // Rewrite server info in case it was just a place holder which was written before.
+      if (serverInfo && serverInfoMessageStart >= 0)
+      {
+        // Found the correct location. Seek the stream to here and write a new FrameCount control message.
+        stream.seekp(serverInfoMessageStart);
+        PacketWriter packet(headerBuffer.data(), uint16_t(headerBuffer.size()), MtServerInfo);
 
-      //   _serverInfo.write(packet);
-      //   packet.finalise();
-      //   stream.write((const char *)headerBuffer.data(), packet.packetSize());
-      //   stream.flush();
-      // }
+        serverInfo->write(packet);
+        packet.finalise();
+        stream.write((const char *)headerBuffer.data(), packet.packetSize());
+        stream.flush();
+      }
 
       if (frameCountMessageStart >= 0)
       {

--- a/3es-core/3esstreamutil.h
+++ b/3es-core/3esstreamutil.h
@@ -1,0 +1,38 @@
+//
+// author: Kazys Stepanas
+//
+#ifndef _3ESSTREAMUTIL_H_
+#define _3ESSTREAMUTIL_H_
+
+#include "3es-core.h"
+
+#include <iosfwd>
+
+namespace tes
+{
+struct ServerInfoMessage;
+
+  namespace streamutil
+  {
+    /// Initialises the file stream ensuring the @p serverInfo and a preliminary @c CIdFrameCount @c ControlMessage are
+    /// written. The frame count is corrected on calling @c finaliseStream().
+    ///
+    /// In some cases a @c ServerInfoMessage may already be written, such as in a @c FileConnection. For this the
+    /// @p serverInfo argument is optional. When @c null, it is assumed to already have been written and only the frame
+    /// count placeholder is established.
+    ///
+    /// @param stream The file stream to initialise. Must support writing.
+    /// @param serverInfo Optional server info to write. When null it is assumed that this has already been written.
+    /// @return True on success, false due to any failure.
+    bool _3es_coreAPI initialiseStream(std::ostream &stream, const ServerInfoMessage *serverInfo);
+
+    /// Finalise a data stream previously initialised with @c initialiseStream(). The @p stream must be seekable for
+    /// read/write so that the initial @c CIdFrameCount @c ControlMessage can be found and fixed.
+    ///
+    /// @param stream The file stream to initialise. Must support reading and writing.
+    /// @return True on success, false due to any failure.
+    bool _3es_coreAPI finaliseStream(std::iostream &stream, unsigned frameCount);
+  } // namespace streamutil
+} // namespace tes
+
+#endif // _3ESSTREAMUTIL_H_

--- a/3es-core/3esstreamutil.h
+++ b/3es-core/3esstreamutil.h
@@ -10,7 +10,7 @@
 
 namespace tes
 {
-struct ServerInfoMessage;
+  struct ServerInfoMessage;
 
   namespace streamutil
   {
@@ -24,14 +24,20 @@ struct ServerInfoMessage;
     /// @param stream The file stream to initialise. Must support writing.
     /// @param serverInfo Optional server info to write. When null it is assumed that this has already been written.
     /// @return True on success, false due to any failure.
-    bool _3es_coreAPI initialiseStream(std::ostream &stream, const ServerInfoMessage *serverInfo);
+    bool _3es_coreAPI initialiseStream(std::ostream &stream, const ServerInfoMessage *serverInfo = nullptr);
 
     /// Finalise a data stream previously initialised with @c initialiseStream(). The @p stream must be seekable for
     /// read/write so that the initial @c CIdFrameCount @c ControlMessage can be found and fixed.
     ///
     /// @param stream The file stream to initialise. Must support reading and writing.
+    /// @param frameCount The final frame count which has been written to the data stream. This value will be written
+    /// to the @c CIdFrameCount @c ControlMessage which appears near the start of the stream.
+    /// @param serverInfo Optional server info structure to rewrite to the stream. When given, this structure is written
+    /// over the existing @c ServerInfoMessage near the start of the stream. This handles cases where the info may not
+    /// be known at the start.
     /// @return True on success, false due to any failure.
-    bool _3es_coreAPI finaliseStream(std::iostream &stream, unsigned frameCount);
+    bool _3es_coreAPI finaliseStream(std::iostream &stream, unsigned frameCount,
+                                     const ServerInfoMessage *serverInfo = nullptr);
   } // namespace streamutil
 } // namespace tes
 

--- a/3es-core/private/3esfileconnection.h
+++ b/3es-core/private/3esfileconnection.h
@@ -32,13 +32,18 @@ namespace tes
     uint16_t port() const override;
     bool isConnected() const override;
 
+    bool sendServerInfo(const ServerInfoMessage &info) override;
+
+    int updateFrame(float dt, bool flush = true) override;
+
   protected:
     int writeBytes(const uint8_t *data, int byteCount) override;
 
   private:
     mutable Lock _fileLock; ///< Lock for @c _outFile() operations
-    std::ofstream _outFile;
+    std::fstream _outFile;
     std::string _filename;
+    unsigned _frameCount = 0;
   };
 }
 

--- a/3es-core/sourcelist.cmake
+++ b/3es-core/sourcelist.cmake
@@ -44,6 +44,7 @@ list(APPEND PUBLIC_HEADERS
   3esservermacros.h
   3esserverutil.h
   3esspinlock.h
+  3esstreamutil.h
   3estcplistensocket.h
   3estcpsocket.h
   3estimer.h
@@ -112,6 +113,7 @@ list(APPEND SOURCES
   3esresourcepacker.cpp
   3esrotation.cpp
   3esspinlock.cpp
+  3esstreamutil.cpp
   3estimer.cpp
   3esvector3.cpp
   3esvector4.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ include(3es-core/cmake/3es-version.cmake)
 set(ConfigPackageLocation lib/cmake/3es)
 
 # C++ standards setup.
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 # Ensure -fPIC is added.
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)

--- a/test/3est-server/3es-server-test.cpp
+++ b/test/3est-server/3es-server-test.cpp
@@ -516,6 +516,7 @@ void showUsage(int argc, char **argv)
   {
     std::cout << "  compress: write collated and compressed packets\n";
   }
+  std::cout << "  file: Save a file stream to 'server-test.3es'\n";
   std::cout << "  noaxes: Don't create axis arrow objects\n";
   std::cout << "  nomove: don't move objects (keep stationary)\n";
   std::cout << "  wire: Show wireframe shapes, not slide for relevant objects\n";
@@ -610,6 +611,12 @@ int main(int argc, char **argvNonConst)
     return 1;
   }
   std::cout << "Listening on port " << server->connectionMonitor()->port() << std::endl;
+
+  if (haveOption("file", argc, argv))
+  {
+    // Record to file stream.
+    server->connectionMonitor()->openFileStream("server-test.3es");
+  }
 
   // Register shapes with server.
   for (Shape *shape : shapes)

--- a/test/3est-unit/3est-common.cpp
+++ b/test/3est-unit/3est-common.cpp
@@ -9,6 +9,7 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <functional>
 
 namespace tes


### PR DESCRIPTION
- Added streamutil to help with finalising 3es file streams.
- FileConnection (file streams) write the final frame count.
- C++ version of 3esrec correctly writes the final frame count
- Bugfix: fixed PacktStream::seeek() to use the endian corrected payloadSize
- Updated to C++17 compilation.